### PR TITLE
support body for post and put

### DIFF
--- a/lib/request_interceptor/runner.rb
+++ b/lib/request_interceptor/runner.rb
@@ -24,6 +24,9 @@ class RequestInterceptor::Runner
   end
 
   def request(request, body, &block)
+    # use Net::HTTP set_body_internal to keep the same behaviour as Net::HTTP
+    request.set_body_internal(body)
+
     application = applications.find { |app| app.hostname_pattern === request["Host"] }
     mock_request = Rack::MockRequest.new(application)
 
@@ -32,9 +35,9 @@ class RequestInterceptor::Runner
       when GET
         mock_request.get(request.path)
       when POST
-        mock_request.post(request.path)
+        mock_request.post(request.path, input: request.body)
       when PUT
-        mock_request.put(request.path)
+        mock_request.put(request.path, input: request.body)
       when DELETE
         mock_request.delete(request.path)
       else

--- a/spec/request_interceptor_spec.rb
+++ b/spec/request_interceptor_spec.rb
@@ -9,8 +9,8 @@ describe RequestInterceptor do
     RequestInterceptor.define(/.*\.example.com/) do
       before { content_type 'text/plain' }
       get("/") { "example.com" }
-      post("/") { halt 201 }
-      put("/") { halt 204 }
+      post("/") { request.body }
+      put("/") { request.body }
       delete("/") { halt 202 }
     end
   end
@@ -59,14 +59,20 @@ describe RequestInterceptor do
 
     it 'intercepts POST request' do
       post_request = Net::HTTP::Post.new(uri)
+      post_request.body = 'test'
       response = http.request(post_request)
-      expect(response).to be_kind_of(Net::HTTPCreated)
+
+      expect(response).to be_kind_of(Net::HTTPOK)
+      expect(response.body).to eq(post_request.body)
     end
 
     it 'intercepts PUT requests' do
       put_request = Net::HTTP::Put.new(uri)
+      put_request.body = 'test'
       response = http.request(put_request)
-      expect(response).to be_kind_of(Net::HTTPNoContent)
+
+      expect(response).to be_kind_of(Net::HTTPOK)
+      expect(response.body).to eq(put_request.body)
     end
 
     it 'intercepts DELETE requests' do


### PR DESCRIPTION
adds body support to put and post. I modified the example to echo the body for these requests. The test suite now asserts for HTTP OK and that the body in the response matches the request.

@t6d 
