### PR TITLE
Refactor request and let non intercepted requests through

### DIFF
--- a/spec/request_interceptor_spec.rb
+++ b/spec/request_interceptor_spec.rb
@@ -80,5 +80,11 @@ describe RequestInterceptor do
       response = http.request(delete_request)
       expect(response).to be_kind_of(Net::HTTPAccepted)
     end
+
+    it 'runs non-intercepted requests like normal' do
+      request = Net::HTTP::Get.new( URI.parse("http://stackoverflow.com/") )
+      response = http.request(request)
+      expect(response.body).to match /Stack Overflow/im
+    end
   end
 end


### PR DESCRIPTION
- Refactors some small methods out of the `request` method.
- Allows non intercepted requests through like usual - this would let this be used in tandem with other http mocking libraries

@t6d 
