### PR TITLE
Custom application templates

### DIFF
--- a/lib/request_interceptor.rb
+++ b/lib/request_interceptor.rb
@@ -3,10 +3,23 @@ require "request_interceptor/version"
 module RequestInterceptor
   class Transaction < Struct.new(:request, :reponse); end
 
-  def self.define(hostname_pattern, &block)
-    Class.new(Application, &block).tap do |app|
-      app.hostname_pattern = hostname_pattern
-    end
+  def self.template=(template)
+    @template =
+      case template
+      when Proc
+        Class.new(Application, &template)
+      else
+        template
+      end
+  end
+
+  def self.template
+    @template || Application
+  end
+
+  def self.define(hostname_pattern, &application_definition)
+    application = Class.new(template, &application_definition)
+    InterceptorDefinition.new(application, hostname_pattern)
   end
 
   def self.run(*applications, &simulation)
@@ -15,5 +28,6 @@ module RequestInterceptor
 end
 
 require "request_interceptor/application"
+require "request_interceptor/interceptor_definition"
 require "request_interceptor/runner"
 require "request_interceptor/status"

--- a/lib/request_interceptor/application.rb
+++ b/lib/request_interceptor/application.rb
@@ -1,10 +1,6 @@
 require "sinatra/base"
 
 class RequestInterceptor::Application < Sinatra::Base
-  class << self
-    attr_accessor :hostname_pattern
-  end
-
   configure do
     disable :show_exceptions
     enable :raise_errors

--- a/lib/request_interceptor/interceptor_definition.rb
+++ b/lib/request_interceptor/interceptor_definition.rb
@@ -1,0 +1,10 @@
+require 'delegate'
+
+class RequestInterceptor::InterceptorDefinition < SimpleDelegator
+  attr_accessor :hostname_pattern
+
+  def initialize(application, hostname_pattern)
+    super(application)
+    @hostname_pattern = hostname_pattern
+  end
+end


### PR DESCRIPTION
It is now possible to customize the application template that is used when defining interceptors via `RequestInterceptor#define` by setting `RequestInterceptor#template`. The writer takes either a class or a proc. In the latter case, the proc is used to define a `Sinatra` application that inherits from `RequestInterceptor::Application`.

@kevinhughes27, please review.
