### PR TITLE
Support for Net:HTTP convenience methods / ActiveResource support

### DIFF
--- a/lib/request_interceptor/runner.rb
+++ b/lib/request_interceptor/runner.rb
@@ -18,12 +18,12 @@ class RequestInterceptor::Runner
   end
 
   def run(&simulation)
-    cache_original_nethttp_methods
-    override_nethttp_methods
+    cache_original_net_http_methods
+    override_net_http_methods
     simulation.call
     transactions
   ensure
-    restore_nethttp_methods
+    restore_net_http_methods
   end
 
   def request(request, body, &block)
@@ -60,13 +60,13 @@ class RequestInterceptor::Runner
 
   private
 
-  def cache_original_nethttp_methods
+  def cache_original_net_http_methods
     @original_request_method = Net::HTTP.instance_method(:request)
     @original_start_method = Net::HTTP.instance_method(:start)
     @original_finish_method = Net::HTTP.instance_method(:finish)
   end
 
-  def override_nethttp_methods
+  def override_net_http_methods
     runner = self
 
     Net::HTTP.class_eval do
@@ -87,7 +87,7 @@ class RequestInterceptor::Runner
     end
   end
 
-  def restore_nethttp_methods
+  def restore_net_http_methods(instance = nil)
     Net::HTTP.send(:define_method, :request, @original_request_method)
     Net::HTTP.send(:define_method, :start, @original_start_method)
     Net::HTTP.send(:define_method, :finish, @original_finish_method)

--- a/lib/request_interceptor/runner.rb
+++ b/lib/request_interceptor/runner.rb
@@ -44,11 +44,20 @@ class RequestInterceptor::Runner
         response.add_field(k, v)
       end
 
+      # copy uri
+      response.uri = request.uri
+
       # copy body to response
       response.body = mock_response.body
 
-      # Net::HTTP#request yields the response
-      block.call(response) if block
+      # replace Net::HTTP::Response#read_body
+      def response.read_body(_, &block)
+        block.call(@body) unless block.nil?
+        @body
+      end
+
+      # yield the response because Net::HTTP#request does
+      block.call(response) unless block.nil?
     else
       response = real_request(http_context, request, body, &block)
     end

--- a/spec/request_interceptor_spec.rb
+++ b/spec/request_interceptor_spec.rb
@@ -81,15 +81,22 @@ describe RequestInterceptor do
       RequestInterceptor.run(example, google) { spec.run }
     end
 
-    it 'intercepts GET requests' do
+    it 'intercepts GET requests when using Net::HTTP#request directly' do
       get_request = Net::HTTP::Get.new(uri)
       get_request['x-counter'] = '42'
       response = http.request(get_request)
       expect(response).to be_kind_of(Net::HTTPOK)
       expect(response['x-counter'].to_i).to eq(43)
+      expect(response.uri).to eq(uri)
     end
 
-    it 'intercepts POST request' do
+    it 'intercepts GET requests when using Net::HTTP#get' do
+      response = http.get(uri.path, 'x-counter' => '42')
+      expect(response).to be_kind_of(Net::HTTPOK)
+      expect(response['x-counter'].to_i).to eq(43)
+    end
+
+    it 'intercepts POST request when using Net::HTTP#request directly' do
       post_request = Net::HTTP::Post.new(uri)
       post_request['x-counter'] = '42'
       post_request.body = 'test'
@@ -98,9 +105,19 @@ describe RequestInterceptor do
       expect(response).to be_kind_of(Net::HTTPCreated)
       expect(response.body).to eq(post_request.body)
       expect(response['x-counter'].to_i).to eq(43)
+      expect(response.uri).to eq(uri)
     end
 
-    it 'intercepts PUT requests' do
+    it 'intercepts POST request when using Net::HTTP#post' do
+      body = 'test'
+      response = http.post(uri.path, body, 'x-counter' => '42')
+
+      expect(response).to be_kind_of(Net::HTTPCreated)
+      expect(response.body).to eq(body)
+      expect(response['x-counter'].to_i).to eq(43)
+    end
+
+    it 'intercepts PUT requests when using NetHTTP#request directly' do
       put_request = Net::HTTP::Put.new(uri)
       put_request.body = 'test'
       put_request['x-counter'] = '42'
@@ -109,12 +126,29 @@ describe RequestInterceptor do
       expect(response).to be_kind_of(Net::HTTPOK)
       expect(response.body).to eq(put_request.body)
       expect(response['x-counter'].to_i).to eq(43)
+      expect(response.uri).to eq(uri)
     end
 
-    it 'intercepts DELETE requests' do
+    it 'intercepts PUT requests when using Net::HTTP#put' do
+      body = 'test'
+      response = http.put(uri.path, body, 'x-counter' => '42')
+
+      expect(response).to be_kind_of(Net::HTTPOK)
+      expect(response.body).to eq(body)
+      expect(response['x-counter'].to_i).to eq(43)
+    end
+
+    it 'intercepts DELETE requests when using Net::HTTP#request directly' do
       delete_request = Net::HTTP::Delete.new(uri)
       delete_request['x-counter'] = '42'
       response = http.request(delete_request)
+      expect(response).to be_kind_of(Net::HTTPAccepted)
+      expect(response['x-counter'].to_i).to eq(43)
+      expect(response.uri).to eq(uri)
+    end
+
+    it 'intercepts DELETE requests when using Net::HTTP#delete' do
+      response = http.delete(uri.path, 'x-counter' => '42')
       expect(response).to be_kind_of(Net::HTTPAccepted)
       expect(response['x-counter'].to_i).to eq(43)
     end

--- a/spec/request_interceptor_spec.rb
+++ b/spec/request_interceptor_spec.rb
@@ -121,7 +121,7 @@ describe RequestInterceptor do
 
     it 'runs non-intercepted requests like normal' do
       request = Net::HTTP::Get.new( URI.parse("http://stackoverflow.com/") )
-      response = http.request(request)
+      response = Net::HTTP.new("stackoverflow.com").request(request)
       expect(response.body).to match /Stack Overflow/im
     end
   end


### PR DESCRIPTION
Adds support for Net::HTTP#get, Net::HTTP#post, Net::HTTP#put, and Net::HTTP#delete, which use blocks internally to read the response body. Block support was broken before. These methods are excerside by ActiveResource, which is now supported.
