### PR TITLE
Only log intercepted transactions

### DIFF
--- a/lib/request_interceptor.rb
+++ b/lib/request_interceptor.rb
@@ -4,7 +4,7 @@ require "net/http"
 require "rack/mock"
 
 class RequestInterceptor
-  class Transaction < Struct.new(:request, :reponse); end
+  class Transaction < Struct.new(:request, :response); end
 
   GET = "GET".freeze
   POST = "POST".freeze

--- a/lib/request_interceptor.rb
+++ b/lib/request_interceptor.rb
@@ -93,11 +93,12 @@ class RequestInterceptor
 
       # yield the response because Net::HTTP#request does
       block.call(response) unless block.nil?
+
+      # log intercepted transaction
+      log_transaction(request, response)
     else
       response = real_request(http_context, request, body, &block)
     end
-
-    log_transaction(request, response)
 
     response
   end


### PR DESCRIPTION
Previously, all transactions were logged, intercepted and non-intercepted / real HTTP requests. Now, an interceptor keeps only track of the calls it served itself. This makes writing test that use multiple nested interceptors a lot easier.
