### PR TITLE
RSpec Matcher

### DIFF
--- a/lib/request_interceptor/matchers.rb
+++ b/lib/request_interceptor/matchers.rb
@@ -1,0 +1,159 @@
+module RequestInterceptor::Matchers
+  class MatcherWrapper < SimpleDelegator
+    def ===(object)
+      matches?(object)
+    end
+
+    def to_s
+      description
+    end
+  end
+
+  class InterceptedRequest
+    attr_reader :method
+    attr_reader :path
+    attr_reader :query
+    attr_reader :body
+    attr_reader :transactions
+
+    def initialize(method, path)
+      @method = method
+      @path = path
+      @count = (1..Float::INFINITY)
+      @transactions = []
+    end
+
+    ##
+    # Chains
+    ##
+
+    def count(count = nil)
+      return @count if count.nil?
+
+      @count =
+        case count
+        when Integer
+          (count .. count)
+        when Range
+          count
+        else
+          raise ArgumentError
+        end
+
+      self
+    end
+
+    def with_query(query)
+      query_matcher =
+        if query.respond_to?(:matches?) && query.respond_to?(:failure_message)
+          query
+        else
+          RSpec::Matchers::BuiltIn::Eq.new(query)
+        end
+
+      @query = MatcherWrapper.new(query_matcher)
+
+      self
+    end
+
+    def with_body(body)
+      body_matcher =
+        if body.respond_to?(:matches?) && body.respond_to?(:failure_message)
+          body
+        else
+          eq(body)
+        end
+
+      @body = MatcherWrapper.new(body_matcher)
+
+      self
+    end
+
+    ##
+    # Rspec Matcher Protocol
+    ##
+
+    def matches?(transactions)
+      @transactions = transactions
+      count.cover?(matching_transactions.count)
+    end
+
+    def failure_message
+      expected_request = "#{format_method(method)} #{path}"
+      expected_request += " with query #{format_object(query)}" if query
+      expected_request += " and" if query && body
+      expected_request += " with body #{format_object(body)}" if body
+
+      similar_intercepted_requests = similar_transactions.map.with_index do |transaction, index|
+        method = format_method(transaction.request.method)
+        path = transaction.request.path
+        query = transaction.request.query
+        body = transaction.request.body
+        indentation_required = index != 0
+
+        message = "#{method} #{path}"
+        message += (query.nil? || query.empty?) ? " with no query" : " with query #{format_object(query)}"
+        message += (body.nil? || body.empty?) ? " and with no body" : " and with body #{format_object(body)}"
+        message = " " * 10 + message if indentation_required
+        message
+      end
+
+      similar_intercepted_requests = ["none"] if similar_intercepted_requests.none?
+
+      "\nexpected: #{expected_request}" \
+        "\n     got: #{similar_intercepted_requests.join("\n")}"
+    end
+
+    def failure_message_when_negated
+      message = "intercepted a #{format_method(method)} request to #{path}"
+      message += " with query #{format_object(query)}" if query
+      message += " and" if query && body
+      message += " with body #{format_object(body)}" if body
+      message
+    end
+
+    def description
+      "should intercept a #{format_method(method)} request to #{path}"
+    end
+
+    ##
+    # Helper methods
+    ##
+
+    private
+
+    def format_method(method)
+      method.to_s.upcase
+    end
+
+    def format_object(object)
+      RSpec::Support::ObjectFormatter.format(object)
+    end
+
+    def matching_transactions
+      transactions.select do |transaction|
+        request = transaction.request
+        request.method?(method) &&
+          request.path?(path) &&
+          request.query?(query) &&
+          request.body?(body)
+      end
+    end
+
+    def similar_transactions
+      transactions.select do |transaction|
+        request = transaction.request
+        request.method?(method) && request.path?(path)
+      end
+    end
+  end
+
+  def have_intercepted_request(*args)
+    InterceptedRequest.new(*args)
+  end
+  alias contain_intercepted_request have_intercepted_request
+end
+
+RSpec.configure do |config|
+  config.include(RequestInterceptor::Matchers)
+end

--- a/lib/request_interceptor/transaction.rb
+++ b/lib/request_interceptor/transaction.rb
@@ -1,0 +1,83 @@
+class RequestInterceptor::Transaction
+  class HTTPMessage
+    include SmartProperties
+    property :body
+
+    def initialize(*args, headers: {}, **kwargs)
+      @headers = headers.dup
+      super(*args, **kwargs)
+    end
+
+    def [](name)
+      @headers[name]
+    end
+
+    def []=(name, value)
+      @headers[name] = value
+    end
+
+    def headers
+      @headers.dup
+    end
+  end
+
+  class Request < HTTPMessage
+    property :method, converts: ->(method) { method.to_s.upcase.freeze }, required: true
+    property :uri, accepts: URI, converts: ->(uri) { URI(uri.to_s) }, required: true
+    property :body
+
+    def method?(method)
+      normalized_method = method.to_s.upcase
+      normalized_method == self.method
+    end
+
+    def path?(path)
+      path === self.path
+    end
+
+    def path
+      uri.path
+    end
+
+    def request_uri?(request_uri)
+      request_uri === self.request_uri
+    end
+
+    def request_uri
+      uri.request_uri
+    end
+
+    def query
+      Rack::Utils.parse_nested_query(uri.query).deep_symbolize_keys!
+    end
+
+    def query?(query_matcher)
+      return true if query_matcher.nil?
+      query_matcher === self.query
+    end
+
+    def body?(body_matcher)
+      return true if body_matcher.nil?
+
+      body = case self["Content-Type"]
+      when "application/json"
+        ActiveSupport::JSON.decode(self.body).deep_symbolize_keys!
+      else
+        self.body
+      end
+
+      body_matcher === body
+    end
+  end
+
+  class Response < HTTPMessage
+    property :status_code, required: true
+    property :body
+  end
+
+  include SmartProperties
+
+  property :request, accepts: Request
+  property :response, accepts: Response
+end
+

--- a/request_interceptor.gemspec
+++ b/request_interceptor.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "sinatra"
   spec.add_runtime_dependency "rack"
   spec.add_runtime_dependency "webmock", "~> 3.0"
+  spec.add_runtime_dependency "smart_properties", "~> 1.0"
+  spec.add_runtime_dependency "activesupport", ">= 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/request_interceptor_spec.rb
+++ b/spec/request_interceptor_spec.rb
@@ -50,17 +50,21 @@ describe RequestInterceptor do
 
   it 'should keep a log of all requests and responses' do
     log = interceptor.run do
-      Net::HTTP.get(URI("http://test.example.com"))
-      Net::HTTP.get(URI("http://test.google.com"))
+      Net::HTTP.get(URI("http://test.example.com/?id=1"))
+      Net::HTTP.get(URI("http://test.google.com/?id=2"))
     end
 
     expect(log.count).to eq(2)
 
     expect(log.first.request.path).to eq("/")
-    expect(log.first.request.uri).to eq(URI("http://test.example.com"))
+    expect(log.first.request.uri).to eq(URI("http://test.example.com/?id=1"))
 
     expect(log.last.request.path).to eq("/")
-    expect(log.last.request.uri).to eq(URI("http://test.google.com"))
+    expect(log.last.request.uri).to eq(URI("http://test.google.com/?id=2"))
+
+    expect(log).to have_intercepted_request(:get, "/").count(2)
+    expect(log).to have_intercepted_request(:get, "/").count(1).with_query(id: "1")
+    expect(log).to have_intercepted_request(:get, "/").count(1).with_query(including(id: "2"))
   end
 
   it 'should normalize urls to remove redundant port information before matching them against the hostname' do

--- a/spec/request_interceptor_spec.rb
+++ b/spec/request_interceptor_spec.rb
@@ -233,9 +233,9 @@ describe RequestInterceptor do
     end
 
     it 'runs non-intercepted requests like normal' do
-      request = Net::HTTP::Get.new( URI.parse("http://stackoverflow.com/") )
-      response = Net::HTTP.new("stackoverflow.com").request(request)
-      expect(response.body).to match(/Stack Overflow/im)
+      request = Net::HTTP::Get.new(URI.parse("https://example.com/") )
+      response = Net::HTTP.new("example.com").request(request)
+      expect(response.body).to match(/Example Domain/im)
     end
   end
 

--- a/spec/rspec_matchers_spec.rb
+++ b/spec/rspec_matchers_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+
+describe RequestInterceptor::Matchers::InterceptedRequest do
+  it "matches againest the HTTP method and the request path by default" do
+    transactions = [
+      transaction(:get, "http://example.com/articles"),
+      transaction(:post, "http://example.com/articles")
+    ]
+
+    matcher = described_class.new("GET", "/articles")
+
+    expect(matcher.matches?(transactions)).to be(true)
+  end
+
+  it "supports matching the request count" do
+    transactions = [
+      transaction(:get, "http://example.com/articles"),
+      transaction(:get, "http://example.com/articles")
+    ]
+
+    matcher = described_class.new("GET", "/articles").count(2)
+    expect(matcher.matches?(transactions)).to be(true)
+
+    matcher = described_class.new("GET", "/articles").count(1)
+    expect(matcher.matches?(transactions)).to be(false)
+  end
+
+
+  it "supports matching the request query parameters" do
+    transactions = [
+      transaction(:get, "http://example.com/articles?param=1"),
+      transaction(:get, "http://example.com/articles")
+    ]
+
+    matcher = described_class.new("GET", "/articles").with_query(including(param: "1"))
+    expect(matcher.matches?(transactions)).to be(true)
+
+    matcher = described_class.new("GET", "/articles").with_query(including(non_existing_param: "1"))
+    expect(matcher.matches?(transactions)).to be(false)
+  end
+
+  it "supports matching the request body" do
+    new_article = {title: "Hello World!", content: "This is my first article."}.to_json
+    transactions = [
+      transaction(:post, "http://example.com/articles", new_article, "Content-Type" => "application/json"),
+    ]
+
+    matcher = described_class.new("POST", "/articles").with_body(including(title: "Hello World!"))
+    expect(matcher.matches?(transactions)).to be(true)
+
+    matcher = described_class.new("POST", "/articles").with_body(including(title: "Hello Ruby!"))
+    expect(matcher.matches?(transactions)).to be(false)
+  end
+
+  it "includes method and path into the description" do
+    matcher = described_class.new("POST", "/articles")
+    expect(matcher.description).to eq("should intercept a POST request to /articles")
+  end
+
+  it "includes expected method, path, query and body in the failure message" do
+    matcher = described_class.new("POST", "/articles").with_query(including(id: "1")).with_body(matching("Hello World!"))
+    expect(matcher.failure_message).to match("expected: POST /articles with query including {:id => \"1\"} and with body matching \"Hello World!\"")
+  end
+
+  it "include similar requests in the failure message; that is request with matching method and path" do
+    transactions = [
+      transaction(:post, "http://example.com/articles?id=2", "Hello World"),
+      transaction(:post, "http://example.com/articles?id=1", "Hola Mundo")
+    ]
+
+    matcher = described_class.new("POST", "/articles").with_query(including(id: 1)).with_body(matching("Hello World!"))
+    matcher.matches?(transactions)
+
+    expect(matcher.failure_message).to match("got: POST /articles with query {:id=>\"2\"} and with body \"Hello World\"")
+    expect(matcher.failure_message).to match("POST /articles with query {:id=>\"1\"} and with body \"Hola Mundo\"")
+  end
+
+  it "outputs if no similar request could be found" do
+    matcher = described_class.new("POST", "/articles").with_query(including(id: 1)).with_body(matching("Hello World!"))
+    expect(matcher.failure_message).to match("got: none")
+  end
+
+  it "includes expected method, path, query and body in the negated failure message" do
+    matcher = described_class.new("POST", "/articles").with_query(including(id: "1")).with_body(matching("Hello World!"))
+    expect(matcher.failure_message_when_negated).to match("intercepted a POST request to /articles with query including {:id => \"1\"} and with body matching \"Hello World!\"")
+  end
+
+  private
+
+  def transaction(method, uri, body = nil, headers = {})
+    RequestInterceptor::Transaction.new(
+      request: RequestInterceptor::Transaction::Request.new(method: method, uri: uri, body: body, headers: headers),
+      response: RequestInterceptor::Transaction::Response.new(status_code: 200)
+    )
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'request_interceptor'
 require 'pry'
+
+require 'request_interceptor'
+require 'request_interceptor/matchers'


### PR DESCRIPTION
The changes include

* refactoring the internals of Request Interceptor and
* introducing an RSpec Matcher.

The latter motivated the former. While working on the matcher, I realized that `Rack::MockRequest` and `Rack::MockResponse` don't provide the interface required to support a clean matcher implementation. Hence, I decided to implement custom classes for describing HTTP transactions. The upside of this approach is that the new interface is guaranteed to be stable and has been tailored to the problem Request Interceptor seeks to solve.

The matcher itself supports matching against

* the request method,
* the path,
* the query parameters, and
* the request body.

For more details, see the README.